### PR TITLE
Added support for python3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
     },
     install_requires=[
         'argh',
-        'kazoo'
+        'kazoo',
+        'future'
     ],
     extras_require = {
        'ui': [

--- a/zkie/__init__.py
+++ b/zkie/__init__.py
@@ -4,11 +4,16 @@ from __future__ import print_function
 
 import json
 import os
-import urlparse
 
 import argh
 from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeError
+from future.standard_library import install_aliases
+install_aliases()
+
+from urllib.parse import urlparse, urlencode
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError
 
 try:
     from pygments.lexers import guess_lexer_for_filename, guess_lexer, JsonLexer, HexdumpLexer


### PR DESCRIPTION
Hi i was playing around with zkie and find out, that when used with python 3 there is problem with renaming of urlib module. I followed recommendentions from this page http://python-future.org/compatible_idioms.html#urllib-module and it seems to work fine. 